### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/server/podman-compose.yml
+++ b/server/podman-compose.yml
@@ -39,7 +39,7 @@ services:
       - postgresql_data:/var/lib/postgresql/data
 
   postgresql-exporter:
-    image: "docker.io/bitnamilegacy/postgres-exporter:0.17.1"
+    image: "docker.io/soldevelo/postgres-exporter:0.17.1"
     environment:
       DATA_SOURCE_NAME: "postgresql://artemis:artemis@postgresql:5432/artemis?sslmode=disable"
       PG_EXPORTER_EXTEND_QUERY_PATH: /tmp/queries.yaml
@@ -47,7 +47,7 @@ services:
       - ./configuration/podman-compose/postgresql-exporter/custom-metrics.yaml:/tmp/queries.yaml:Z,ro
 
   prometheus:
-    image: "docker.io/bitnamilegacy/prometheus:3.0.1"
+    image: "docker.io/soldevelo/prometheus:3.0.1"
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnamilegacy/postgres-exporter:0.17.1` → [`soldevelo/postgres-exporter:0.17.1`](https://hub.docker.com/r/soldevelo/postgres-exporter)
- `bitnamilegacy/prometheus:3.0.1` → [`soldevelo/prometheus:3.0.1`](https://hub.docker.com/r/soldevelo/prometheus)